### PR TITLE
Column\Action skip content generated with Formatters

### DIFF
--- a/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
@@ -223,7 +223,7 @@ class Renderer extends AbstractRenderer
                 } elseif ($column instanceof Column\Action) {
                     /* @var $column \ZfcDatagrid\Column\Action */
 
-                    if ($columnActions = $column->getActions()) {
+                    if ($column->getActions()) {
                         $actions = [];
                         foreach ($column->getActions() as $action) {
                             /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */

--- a/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
@@ -223,16 +223,17 @@ class Renderer extends AbstractRenderer
                 } elseif ($column instanceof Column\Action) {
                     /* @var $column \ZfcDatagrid\Column\Action */
 
-                    $actions = [];
-                    foreach ($column->getActions() as $action) {
-                        /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */
-                        if ($action->isDisplayed($row) === true) {
-                            $action->setTitle($this->translate($action->getTitle()));
-                            $actions[] = $action->toHtml($row);
+                    if ($columnActions = $column->getActions()) {
+                        $actions = [];
+                        foreach ($column->getActions() as $action) {
+                            /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */
+                            if ($action->isDisplayed($row) === true) {
+                                $action->setTitle($this->translate($action->getTitle()));
+                                $actions[] = $action->toHtml($row);
+                            }
                         }
+                        $row[$column->getUniqueId()] = implode(' ', $actions);
                     }
-
-                    $row[$column->getUniqueId()] = implode(' ', $actions);
                 } elseif ($column instanceof Column\Action\Icon) {
                     $row[$column->getUniqueId()] = $column->getIconClass();
                 }


### PR DESCRIPTION
This PR fix problem with empty "actions" in `\ZfcDatagrid\Column\Action`.
For example, I have next code which should adds Action column with icon and link. 
```php
$fmtr = new Column\Formatter\Link();
$fmtr->setAttribute('class', 'pencil-edit-icon');
$fmtr->setLink('/invoice/view/' . $fmtr->getColumnValuePlaceholder($colId));
$actions = new Column\Action('edit');
$actions->setLabel(' ');
$actions->setFormatters([$fmtr]);
$grid->addColumn($actions);
```
This should render `<a>` with Formatter but instead return empty string.

The generated link [comes here](https://www.screencast.com/t/ynbyFNzYlIB), but the empty string [is returned](https://www.screencast.com/t/TWQMUaN2A).