### PR TITLE
Issue #52: Allow changing column type's filterDefaultOperation

### DIFF
--- a/src/ZfcDatagrid/Column/Type/AbstractType.php
+++ b/src/ZfcDatagrid/Column/Type/AbstractType.php
@@ -7,13 +7,35 @@ use ZfcDatagrid\Filter;
 abstract class AbstractType implements TypeInterface
 {
     /**
+     * @var string
+     */
+    protected $filterDefaultOperation = Filter::LIKE;
+
+    /**
      * the default filter operation.
      *
      * @return string
      */
     public function getFilterDefaultOperation()
     {
-        return Filter::LIKE;
+        return $this->filterDefaultOperation;
+    }
+
+    /**
+     * @param string $operator
+     *
+     * @return $this
+     * @throws \Exception
+     */
+    public function setFilterDefaultOperation($operator)
+    {
+        if (! in_array($operator, Filter::AVAILABLE_OPERATORS)) {
+            throw new \InvalidArgumentException(sprintf('Invalid filter operator \'%s\'', strval($operator)));
+        }
+
+        $this->filterDefaultOperation = $operator;
+
+        return $this;
     }
 
     /**

--- a/src/ZfcDatagrid/Column/Type/DateTime.php
+++ b/src/ZfcDatagrid/Column/Type/DateTime.php
@@ -10,6 +10,11 @@ use ZfcDatagrid\Filter;
 
 class DateTime extends AbstractType
 {
+    /**
+     * @var string
+     */
+    protected $filterDefaultOperation = Filter::GREATER_EQUAL;
+
     protected $daterangePickerEnabled = false;
 
     protected $sourceDateTimeFormat;
@@ -173,11 +178,6 @@ class DateTime extends AbstractType
     public function getOutputPattern()
     {
         return $this->outputPattern;
-    }
-
-    public function getFilterDefaultOperation()
-    {
-        return Filter::GREATER_EQUAL;
     }
 
     /**

--- a/src/ZfcDatagrid/Column/Type/Number.php
+++ b/src/ZfcDatagrid/Column/Type/Number.php
@@ -9,6 +9,11 @@ use ZfcDatagrid\Filter;
 class Number extends AbstractType
 {
     /**
+     * @var string
+     */
+    protected $filterDefaultOperation = Filter::EQUAL;
+
+    /**
      * Locale to use instead of the default.
      *
      * @var string
@@ -142,11 +147,6 @@ class Number extends AbstractType
     public function getPattern()
     {
         return $this->pattern;
-    }
-
-    public function getFilterDefaultOperation()
-    {
-        return Filter::EQUAL;
     }
 
     /**

--- a/src/ZfcDatagrid/Column/Type/TypeInterface.php
+++ b/src/ZfcDatagrid/Column/Type/TypeInterface.php
@@ -10,4 +10,19 @@ interface TypeInterface
      * @return string
      */
     public function getTypeName();
+
+    /**
+     * the default filter operation.
+     *
+     * @return string
+     */
+    public function getFilterDefaultOperation();
+
+    /**
+     * @param string $operator
+     *
+     * @return $this
+     * @throws \Exception
+     */
+    public function setFilterDefaultOperation($operator);
 }

--- a/src/ZfcDatagrid/Filter.php
+++ b/src/ZfcDatagrid/Filter.php
@@ -56,6 +56,29 @@ class Filter
     const BETWEEN = '%s <> %s';
 
     /**
+     * List of all available operations
+     *
+     * @var array
+     */
+    const AVAILABLE_OPERATORS = [
+        self::LIKE,
+        self::LIKE_LEFT,
+        self::LIKE_RIGHT,
+        self::NOT_LIKE,
+        self::NOT_LIKE_LEFT,
+        self::NOT_LIKE_RIGHT,
+        self::EQUAL,
+        self::NOT_EQUAL,
+        self::GREATER_EQUAL,
+        self::GREATER,
+        self::LESS_EQUAL,
+        self::LESS,
+        self::IN,
+        self::NOT_IN,
+        self::BETWEEN,
+    ];
+
+    /**
      * @var Column\AbstractColumn
      */
     private $column;

--- a/tests/ZfcDatagridTest/Column/Type/AbstractTypeTest.php
+++ b/tests/ZfcDatagridTest/Column/Type/AbstractTypeTest.php
@@ -22,9 +22,24 @@ class AbstractTypeTest extends TestCase
         $this->type = $this->getMockForAbstractClass(\ZfcDatagrid\Column\Type\AbstractType::class);
     }
 
-    public function testGetFilterDefaultOperation()
+    /**
+     * @throws \Exception
+     */
+    public function testFilterDefaultOperation()
     {
+        // Test default value.
         $this->assertEquals(Filter::LIKE, $this->type->getFilterDefaultOperation());
+
+        // Set incorrect value.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->type->setFilterDefaultOperation('invalid');
+        $this->assertEquals(Filter::LIKE, $this->type->getFilterDefaultOperation());
+
+        // Set correct value.
+        foreach (Filter::AVAILABLE_OPERATORS as $operator) {
+            $this->assertSame($this->type, $this->type->setFilterDefaultOperation($operator));
+            $this->assertEquals($operator, $this->type->getFilterDefaultOperation());
+        }
     }
 
     public function testGetFilterValue()


### PR DESCRIPTION
I've changed the following:

1. In `ZfcDatagrid\Column\AbstractType`: The `filterDefaultOperation` value is now stored in a protected property. The setter allows changing that value as long as the value is in the list of allowed filter operators.
2. In `ZfcDatagrid\Filter`: There is now a new class constant containing a list of all the available filter operators. This class constant is used for validation in the setter `ZfcDatagrid\Column\AbstractType::setFilterDefaultOperation`.
3. The types extending `ZfcDatagrid\Column\AbstractType` have their different filter operators set in the newly introduced protected property, when applicable. The getters have been removed since they're already available in their parent class.
4. I've add the methods `getFilterDefaultOperation` and `setFilterDefaultOperation` to the `TypeInterface`.