### PR TITLE
Add datagrid filters instead of using the columns filters

### DIFF
--- a/src/ZfcDatagrid/DataSource/PhpArray.php
+++ b/src/ZfcDatagrid/DataSource/PhpArray.php
@@ -55,7 +55,7 @@ class PhpArray extends AbstractDataSource
          */
         foreach ($this->getFilters() as $filter) {
             /* @var $filter \ZfcDatagrid\Filter */
-            if ($filter->isColumnFilter() === true) {
+            if ($filter->isColumnFilter() === true || $filter->isFormFilter() === true) {
                 $data = array_filter($data, [
                     new PhpArray\Filter($filter),
                     'applyFilter',

--- a/src/ZfcDatagrid/DataSource/PhpArray/Filter.php
+++ b/src/ZfcDatagrid/DataSource/PhpArray/Filter.php
@@ -43,7 +43,12 @@ class Filter
 
         foreach ($this->getFilter()->getValues() as $filterValue) {
             $filter = $this->getFilter();
-            $col = $filter->getColumn();
+            
+            if ($filter->isColumnFilter() === true) {
+                $col = $filter->getColumn();
+            } else if($filter->isFormFilter() === true) {
+                $col = $filter->getFormFilter();
+            }
 
             $value = $row[$col->getUniqueId()];
             $value = $col->getType()->getFilterValue($value);

--- a/src/ZfcDatagrid/FormFilter/AbstractFilter.php
+++ b/src/ZfcDatagrid/FormFilter/AbstractFilter.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace ZfcDatagrid\FormFilter;
+
+use ZfcDatagrid\Column\Type;
+
+abstract class AbstractFilter
+{
+    protected $label = '';
+
+    protected $width = 5;
+
+    protected $uniqueId;
+    
+    protected $filterActiveValue;
+    
+    /**
+     * @var Type\AbstractType
+     */
+    protected $type = null;
+    
+    /**
+     * @param $name
+     */
+    public function setLabel($name)
+    {
+        $this->label = (string) $name;
+    }
+
+    /**
+     * Get the label.
+     *
+     * @return string null
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    /**
+     * @param int|null $position
+     * @return AbstractColumn
+     */
+    public function setPosition($position)
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+
+    /**
+     * Set the width in "percent"
+     * It will be calculated to 100% dependend on what is displayed
+     * If it's a different output mode like Excel it's dependend on the papersize/orientation.
+     *
+     * @param number $percent
+     */
+    public function setWidth($percent)
+    {
+        $this->width = (float) $percent;
+    }
+
+    /**
+     * Get the width.
+     *
+     * @return number
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+    
+    
+    public function setUniqueId($uniqueId)
+    {
+        $this->uniqueId = $uniqueId;   
+    }
+    
+    public function getUniqueId()
+    {
+        return $this->uniqueId;
+    }
+    
+    /**
+     * @param mixed $value
+     */
+    public function setFilterActive($value = '')
+    {
+        $this->filterActive = (bool) true;
+        $this->filterActiveValue = $value;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getFilterActiveValue()
+    {
+        return $this->filterActiveValue;
+    }
+    
+    /**
+     * Set the formFilter type.
+     *
+     * @param Type\AbstractType $type
+     */
+    public function setType(Type\AbstractType $type)
+    {
+        if ($type instanceof Type\Image && $this->hasFormatters() === false) {
+            $this->addFormatter(new Formatter\Image());
+            $this->setRowClickDisabled(true);
+        }
+        
+        $this->type = $type;
+    }
+    
+    /**
+     * @return Type\AbstractType
+     */
+    public function getType()
+    {
+        if (null === $this->type) {
+            $this->type = new Type\PhpString();
+        }
+        
+        return $this->type;
+    }
+}

--- a/src/ZfcDatagrid/FormFilter/Text.php
+++ b/src/ZfcDatagrid/FormFilter/Text.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace ZfcDatagrid\FormFilter;
+
+class Text extends AbstractFilter
+{
+    /** @var string */
+    protected $selectPart1;
+
+    /** @var string|object|null */
+    protected $selectPart2 = null;
+
+    /**
+     * Specific column function filter e.g.
+     * WHERE MONTH(%s).
+     *
+     * @var string
+     */
+    private $filterSelectExpression;
+
+    /**
+     * Possible calls:
+     * $column = new Column('id', 'user')
+     * Select the id from the user table -> UNIQUE is the comination of both
+     * $column = new Column('title')
+     * Just the title from an array -> UNIQUE will be just the first parameter
+     * $column = new Column('(SELECT GROUP_CONCAT....)', 'someAlias')
+     * Use the subselect -> UNIQUE will be the second parameter.
+     *
+     * @param string|object $columnOrIndexOrObject
+     * @param string|null   $tableOrAliasOrUniqueId
+     *
+     * @throws \Exception
+     */
+    public function __construct($columnOrIndexOrObject, $tableOrAliasOrUniqueId = null)
+    {
+        if ($tableOrAliasOrUniqueId !== null && ! is_string($tableOrAliasOrUniqueId)) {
+            throw new \Exception('Variable $tableOrAliasOrUniqueId must be null or a string');
+        }
+
+        if (is_string($columnOrIndexOrObject) && $tableOrAliasOrUniqueId !== null) {
+           $this->setUniqueId($tableOrAliasOrUniqueId.'_'.$columnOrIndexOrObject);
+            $this->setSelect($tableOrAliasOrUniqueId, $columnOrIndexOrObject);
+        } elseif (is_string($columnOrIndexOrObject)) {
+            $this->setUniqueId($columnOrIndexOrObject);
+            $this->setSelect($columnOrIndexOrObject);
+        } elseif (is_object($columnOrIndexOrObject) &&
+            null !== $tableOrAliasOrUniqueId &&
+            is_string($tableOrAliasOrUniqueId)
+        ) {
+           $this->setUniqueId($tableOrAliasOrUniqueId);
+            $this->setSelect($columnOrIndexOrObject);
+        } else {
+            throw new \Exception('Column was not initiated correctly, please read the __construct docblock!');
+        }
+    }
+
+    /**
+     * @params string $part1
+     * @params string|object|null $part2
+     */
+    public function setSelect($part1, $part2 = null)
+    {
+        $this->selectPart1 = $part1;
+        $this->selectPart2 = $part2;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSelectPart1()
+    {
+        return $this->selectPart1;
+    }
+
+    /**
+     * @return string|object|null
+     */
+    public function getSelectPart2()
+    {
+        return $this->selectPart2;
+    }
+
+    /**
+     * @param string $filterSelectExpression
+     */
+    public function setFilterSelectExpression($filterSelectExpression)
+    {
+        $this->filterSelectExpression = $filterSelectExpression;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilterSelectExpression()
+    {
+        return $this->filterSelectExpression;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasFilterSelectExpression()
+    {
+        return null !== $this->filterSelectExpression;
+    }
+}

--- a/src/ZfcDatagrid/PrepareData.php
+++ b/src/ZfcDatagrid/PrepareData.php
@@ -10,6 +10,11 @@ class PrepareData
      * @var array
      */
     private $columns = [];
+    
+    /**
+     * @var array
+     */
+    private $formFilters = [];
 
     /**
      * @var array
@@ -31,11 +36,13 @@ class PrepareData
     /**
      * @param array $data
      * @param array $columns
+     * @param array $formFilters
      */
-    public function __construct(array $data, array $columns)
+    public function __construct(array $data, array $columns, array $formFilters)
     {
         $this->setData($data);
         $this->setColumns($columns);
+        $this->setFormFilters($formFilters);
     }
 
     /**
@@ -54,6 +61,15 @@ class PrepareData
         return $this->columns;
     }
 
+    /**
+     *
+     * @param array $formFilters
+     */
+    public function setFormFilters(array $formFilters)
+    {
+        $this->formFilters = $formFilters;
+    }
+    
     /**
      * @param array $data
      */

--- a/src/ZfcDatagrid/Renderer/AbstractRenderer.php
+++ b/src/ZfcDatagrid/Renderer/AbstractRenderer.php
@@ -42,6 +42,11 @@ abstract class AbstractRenderer implements RendererInterface
      * @var \ZfcDatagrid\Column\AbstractColumn[]
      */
     protected $columns = [];
+    
+    /**
+     * @var \ZfcDatagrid\FormFilter\AbstractFilter[]
+     */
+    protected $formFilters = [];
 
     /**
      * @var \ZfcDataGrid\Column\Style\AbstractStyle[]
@@ -270,6 +275,26 @@ abstract class AbstractRenderer implements RendererInterface
     public function getColumns()
     {
         return $this->columns;
+    }
+    
+    /**
+     * Set the FormFilters.
+     *
+     * @param array $formFilters
+     */
+    public function setFormFilters(array $formFilters)
+    {
+        $this->formFilters = $formFilters;
+    }
+    
+    /**
+     * Get all columns.
+     *
+     * @return \ZfcDatagrid\Column\AbstractColumn[]
+     */
+    public function getFormFilters()
+    {
+        return $this->formFilters;
     }
 
     /**
@@ -666,6 +691,8 @@ abstract class AbstractRenderer implements RendererInterface
         $viewModel->setVariable('generalParameterNames', $generalParameterNames);
 
         $viewModel->setVariable('columns', $this->getColumns());
+        
+        $viewModel->setVariable('formFilters', $this->getFormFilters());
 
         $viewModel->setVariable('rowStyles', $grid->getRowStyles());
 

--- a/src/ZfcDatagrid/Renderer/BootstrapTable/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/BootstrapTable/Renderer.php
@@ -141,15 +141,14 @@ class Renderer extends AbstractRenderer
                             if ($column->getUniqueId() == $uniqueId) {
                                 $filter = new \ZfcDatagrid\Filter();
                                 $filter->setFromColumn($column, $value);
-
                                 $filters[] = $filter;
-
                                 $column->setFilterActive($filter->getDisplayColumnValue());
                             }
                         }
                     }
                 }
             }
+            
             if($formFilters !== null) {
                 foreach ($formFilters as $uniqueId => $value) {
                     if ($value != '') {

--- a/view/zfc-datagrid/renderer/bootstrapTable/layout.phtml
+++ b/view/zfc-datagrid/renderer/bootstrapTable/layout.phtml
@@ -2,7 +2,7 @@
 use ZfcDatagrid\Column\Type;
 
 $hasMassActions = false;
-if(count($this->massActions) > 0){
+if(count($this->massActions) > 0) {
     $hasMassActions = true;
 }
 ?>
@@ -27,7 +27,20 @@ if(count($this->massActions) > 0){
     <input type="hidden" name="<?php echo $this->parameterNames['sortColumns']; ?>" value="<?php echo $this->activeParameters[$this->parameterNames['sortColumns']]; ?>" />
     <input type="hidden" name="<?php echo $this->parameterNames['sortDirections']; ?>" value="<?php echo $this->activeParameters[$this->parameterNames['sortDirections']]; ?>" />
 
+	<?php 
+	foreach($this->formFilters as $formFilter) {
+	    $classes = [];
+	    $htmlFilter = '';
+	    $htmlFilter = sprintf(
+	        '%s<input type="text" name="formFilters[%s]" style="width: 80%%"  value="%s" class="form-control" />',
+	        $formFilter->getLabel(), $formFilter->getUniqueId() , $formFilter->getFilterActiveValue()
+        );
+	    ?>
+        <td class="<?php echo implode(' ', $classes); ?>">
+            <?php echo $htmlFilter; ?>
+        </td>
     <?php
+    }
     foreach($this->parameters as $name => $value){
         echo '<input type="hidden" name="' . $name . '" value="' . $value . '" />';
     }


### PR DESCRIPTION
https://github.com/zfc-datagrid/zfc-datagrid/issues/80#issue-513470631

Adding the FormFilter gives the developer the ability to add filters on the datagrid of specific 
columns without the need to add the columns to the datagrid itself.
1- add the formFilter in the preparation process (when prepareData of the datagrid), where the formFilters
are rendered by setting the formFilters in the renderer

2- layout.phtml was modified to show the formFilter input fields.
The viewModel is modified to add the formFilters in the preparing process #80 