### PR TITLE
Update documentation for SM3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Datagrid/Datatable module for Laminas Framework
+# Datagrid/Datatable module for Laminas Framework (formerly Zend Framework)
 [![Master Branch Build Status](https://secure.travis-ci.org/zfc-datagrid/zfc-datagrid.png?branch=master)](http://travis-ci.org/zfc-datagrid/zfc-datagrid)
 [![Coverage Status](https://coveralls.io/repos/github/zfc-datagrid/zfc-datagrid/badge.svg?branch=master)](https://coveralls.io/github/zfc-datagrid/zfc-datagrid?branch=master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/zfc-datagrid/zfc-datagrid/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/zfc-datagrid/zfc-datagrid/?branch=master)

--- a/docs/02. Quick Start.md
+++ b/docs/02. Quick Start.md
@@ -184,7 +184,7 @@ class IndexControllerFactory
 }
 ```
 
-which is register the factory on `module.config.php`:
+You need register the factory in your `module.config.php`:
 
 ```php
     'controllers' => [

--- a/docs/02. Quick Start.md
+++ b/docs/02. Quick Start.md
@@ -114,7 +114,7 @@ return [
 ## Basic Example
 
 The first datagrid is a really simple one, to see if everything works for you. 
-It'll work if you have ZF-Skeleton installed or Twitter Bootstrap included out of the box.
+It'll work if you have Laminas-Skeleton installed or Twitter Bootstrap included out of the box.
 
 If you copy the following code and paste it into your action, try to call this action (with your defined route) and you should see your 
 first ZfcDatagrid! (Congratulations) It's renderer with the output mode "bootstrapTable", where you can already paginate, filter and sort your data.
@@ -130,6 +130,14 @@ use ZfcDatagrid\Column;
 class IndexController extends AbstractActionController
 {
 
+    /* @var $grid \ZfcDatagrid\Datagrid */
+    protected $datagrid;
+
+    public function __construct($datagrid)
+    {
+        $this->datagrid = $datagrid;
+    }
+
     /**
      * Simple bootstrap table
      *
@@ -144,7 +152,7 @@ class IndexController extends AbstractActionController
         ];
         
         /* @var $grid \ZfcDatagrid\Datagrid */
-        $grid = $this->getServiceLocator()->get('ZfcDatagrid\Datagrid');
+        $grid = $this->datagrid;
         $grid->setTitle('Minimal grid');
         $grid->setDataSource($data);
         
@@ -157,6 +165,33 @@ class IndexController extends AbstractActionController
         return $grid->getResponse();
     }
 }
+```
+
+The factory would looks like following:
+
+```php
+<?php
+namespace Application\Controller;
+
+use Interop\Container\ContainerInterface;
+
+class IndexControllerFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        return new IndexController($container->get('ZfcDatagrid\Datagrid'));
+    }
+}
+```
+
+which is register the factory on `module.config.php`:
+
+```php
+    'controllers' => [
+        'factories' => [
+            IndexController::class => IndexControllerFactory::class,
+        ],
+    ],
 ```
 
 ### Navigation


### PR DESCRIPTION
In  laminas-servicemanager 3.0  `getServiceLocator()` is deprecated.