### PR TITLE
Allow null values for PhpArray datasource

### DIFF
--- a/src/ZfcDatagrid/DataSource/PhpArray/Filter.php
+++ b/src/ZfcDatagrid/DataSource/PhpArray/Filter.php
@@ -44,7 +44,7 @@ class Filter
             $filter = $this->getFilter();
             $col    = $filter->getColumn();
 
-            $value = $row[$col->getUniqueId()];
+            $value = (string) $row[$col->getUniqueId()];
             $value = $col->getType()->getFilterValue($value);
 
             if ($filter->getOperator() == DatagridFilter::BETWEEN) {

--- a/tests/ZfcDatagridTest/DataSource/PhpArray/FilterTest.php
+++ b/tests/ZfcDatagridTest/DataSource/PhpArray/FilterTest.php
@@ -441,4 +441,16 @@ class FilterTest extends TestCase
             'myCol' => '15',
         ]);
     }
+
+    public function testDefaultOperatorWithNullValue()
+    {
+        $filter = new Filter();
+        $filter->setFromColumn($this->column, 'test');
+
+        $filterArray = new FilterArray($filter);
+
+        $this->assertFalse($filterArray->applyFilter([
+            'myCol' => null,
+        ]));
+    }
 }


### PR DESCRIPTION
Cast value to string before providing it to getFilterValue() which accepts string only.
Fixes #88.